### PR TITLE
Refactor SwiftUI news app with MVVM

### DIFF
--- a/SwiftNewsApp/Models/Article.swift
+++ b/SwiftNewsApp/Models/Article.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct Article: Identifiable {
+    let id: Int
+    let title: String
+    let summary: String
+    let source: String
+    let publishedDate: String
+    let imageUrl: String?
+    let isLive: Bool
+    let isTrending: Bool
+}

--- a/SwiftNewsApp/Models/Category.swift
+++ b/SwiftNewsApp/Models/Category.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum Category: String, CaseIterable, Identifiable {
+    case top, world, politics, science, tech
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .top: return "Top News"
+        case .world: return "World"
+        case .politics: return "Politics"
+        case .science: return "Science"
+        case .tech: return "Tech"
+        }
+    }
+}

--- a/SwiftNewsApp/Models/FeaturedArticle.swift
+++ b/SwiftNewsApp/Models/FeaturedArticle.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct FeaturedArticle: Identifiable {
+    let id = UUID()
+    let title: String
+    let summary: String
+    let source: String
+    let publishedDate: String
+    let imageUrl: String
+    let isLive: Bool
+}

--- a/SwiftNewsApp/NewsApp.swift
+++ b/SwiftNewsApp/NewsApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct NewsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SwiftNewsApp/ViewModels/NewsViewModel.swift
+++ b/SwiftNewsApp/ViewModels/NewsViewModel.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Combine
+
+class NewsViewModel: ObservableObject {
+    @Published var selectedCategory: Category = .top
+
+    let breakingNews: String
+    let featuredArticle: FeaturedArticle
+    let articlesByCategory: [Category: [Article]]
+
+    init() {
+        breakingNews = "Supreme Court to hear landmark climate change case next month"
+
+        featuredArticle = FeaturedArticle(
+            title: "Global Climate Summit Reaches Historic Agreement on Carbon Emissions",
+            summary: "World leaders from 195 countries have reached a groundbreaking consensus on reducing carbon emissions by 50% over the next decade, marking the most significant climate action in international history.",
+            source: "The Times",
+            publishedDate: "2 hours ago",
+            imageUrl: "https://images.unsplash.com/photo-1569163139394-de4e4f43e4e3?w=800&h=400&fit=crop",
+            isLive: true
+        )
+
+        articlesByCategory = [
+            .top: [
+                Article(
+                    id: 1,
+                    title: "Tech Giants Face New Regulatory Challenges in European Markets",
+                    summary: "New legislation targeting major technology companies could reshape the digital landscape across Europe, with potential impacts on global operations.",
+                    source: "Business Desk",
+                    publishedDate: "4 hours ago",
+                    imageUrl: "https://images.unsplash.com/photo-1560472355-536de3962603?w=400&h=300&fit=crop",
+                    isLive: false,
+                    isTrending: true
+                ),
+                Article(
+                    id: 2,
+                    title: "Breakthrough in Quantum Computing Promises Revolutionary Changes",
+                    summary: "Scientists at leading research institutions have achieved a major milestone in quantum computing that could accelerate technological advancement.",
+                    source: "Science",
+                    publishedDate: "6 hours ago",
+                    imageUrl: "https://images.unsplash.com/photo-1518709268805-4e9042af2176?w=400&h=300&fit=crop",
+                    isLive: false,
+                    isTrending: false
+                ),
+                Article(
+                    id: 3,
+                    title: "Global Food Security Initiative Launches Across 50 Countries",
+                    summary: "A comprehensive program aimed at addressing food insecurity worldwide has been launched with support from international organizations and governments.",
+                    source: "World News",
+                    publishedDate: "8 hours ago",
+                    imageUrl: "https://images.unsplash.com/photo-1574323347407-f5e1ad6d020b?w=400&h=300&fit=crop",
+                    isLive: false,
+                    isTrending: false
+                )
+            ],
+            .world: [
+                Article(
+                    id: 4,
+                    title: "European Union Announces New Trade Partnership with Southeast Asia",
+                    summary: "Historic agreement aims to boost economic cooperation and sustainable development across regions.",
+                    source: "World News",
+                    publishedDate: "3 hours ago",
+                    imageUrl: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=300&fit=crop",
+                    isLive: false,
+                    isTrending: false
+                ),
+                Article(
+                    id: 5,
+                    title: "Antarctic Research Station Reports Record Ice Sheet Changes",
+                    summary: "Scientists document unprecedented changes in polar ice formations with global implications.",
+                    source: "Science",
+                    publishedDate: "5 hours ago",
+                    imageUrl: nil,
+                    isLive: false,
+                    isTrending: false
+                )
+            ],
+            .politics: [
+                Article(
+                    id: 6,
+                    title: "Congressional Leaders Reach Bipartisan Infrastructure Agreement",
+                    summary: "Landmark legislation promises major investments in clean energy and digital connectivity.",
+                    source: "Politics",
+                    publishedDate: "2 hours ago",
+                    imageUrl: "https://images.unsplash.com/photo-1529107386315-e1a2ed48a620?w=400&h=300&fit=crop",
+                    isLive: false,
+                    isTrending: false
+                )
+            ],
+            .science: [
+                Article(
+                    id: 7,
+                    title: "New Gene Therapy Shows Promise for Treating Rare Genetic Disorders",
+                    summary: "Clinical trials demonstrate significant improvements in patient outcomes using innovative treatment approach.",
+                    source: "Health & Science",
+                    publishedDate: "4 hours ago",
+                    imageUrl: "https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=400&h=300&fit=crop",
+                    isLive: false,
+                    isTrending: false
+                )
+            ],
+            .tech: [
+                Article(
+                    id: 8,
+                    title: "AI Breakthrough: New Model Achieves Human-Level Performance in Complex Reasoning",
+                    summary: "Latest artificial intelligence system demonstrates unprecedented capabilities in problem-solving and analysis.",
+                    source: "Technology",
+                    publishedDate: "1 hour ago",
+                    imageUrl: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?w=400&h=300&fit=crop",
+                    isLive: true,
+                    isTrending: false
+                )
+            ]
+        ]
+    }
+}
+

--- a/SwiftNewsApp/Views/ArticleRow.swift
+++ b/SwiftNewsApp/Views/ArticleRow.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import Foundation
+
+struct ArticleRow: View {
+    let article: Article
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    if article.isLive {
+                        Text("LIVE")
+                            .font(.caption2)
+                            .bold()
+                            .padding(4)
+                            .background(Color.red)
+                            .foregroundColor(.white)
+                            .cornerRadius(3)
+                    }
+                    if article.isTrending {
+                        Text("TRENDING")
+                            .font(.caption2)
+                            .bold()
+                            .padding(4)
+                            .background(Color.orange)
+                            .foregroundColor(.white)
+                            .cornerRadius(3)
+                    }
+                }
+                Text(article.title)
+                    .font(.headline)
+                Text(article.summary)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(3)
+                HStack(spacing: 4) {
+                    Text(article.source)
+                    Text("•")
+                    Text(article.publishedDate)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+            if let url = article.imageUrl, let imgUrl = URL(string: url) {
+                AsyncImage(url: imgUrl) { image in
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Color.gray.opacity(0.3)
+                }
+                .frame(width: 80, height: 80)
+                .clipped()
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/SwiftNewsApp/Views/BreakingNewsBanner.swift
+++ b/SwiftNewsApp/Views/BreakingNewsBanner.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct BreakingNewsBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("BREAKING")
+                .font(.caption).bold()
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.red)
+                .foregroundColor(.white)
+                .cornerRadius(4)
+            Text(message)
+                .font(.caption)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    BreakingNewsBanner(message: "Supreme Court to hear landmark climate case next month")
+}

--- a/SwiftNewsApp/Views/CategoryTabs.swift
+++ b/SwiftNewsApp/Views/CategoryTabs.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct CategoryTabs: View {
+    @Binding var selected: Category
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Category.allCases) { category in
+                    Button(action: { selected = category }) {
+                        Text(category.label)
+                            .font(.subheadline)
+                            .padding(.vertical, 8)
+                            .padding(.horizontal, 12)
+                            .background(selected == category ? Color.gray.opacity(0.2) : Color.clear)
+                            .cornerRadius(8)
+                            .foregroundColor(selected == category ? .primary : .secondary)
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+}

--- a/SwiftNewsApp/Views/ContentView.swift
+++ b/SwiftNewsApp/Views/ContentView.swift
@@ -28,26 +28,23 @@ struct ContentView: View {
     private var homeView: some View {
         NavigationView {
             List {
-                breakingNewsBanner
+                BreakingNewsBanner(message: viewModel.breakingNews)
+                    .listRowInsets(EdgeInsets())
+                CategoryTabs(selected: $viewModel.selectedCategory)
+                    .listRowInsets(EdgeInsets())
                 if viewModel.selectedCategory == .top {
-                    featured
+                    FeaturedArticleView(article: viewModel.featuredArticle)
+                        .listRowInsets(EdgeInsets())
+                    SectionHeaderView(title: "Latest News", subtitle: "Stay updated with breaking stories")
+                        .listRowInsets(EdgeInsets())
                 }
                 ForEach(viewModel.articlesByCategory[viewModel.selectedCategory] ?? []) { article in
                     ArticleRow(article: article)
+                        .listRowInsets(EdgeInsets())
                 }
             }
             .listStyle(.plain)
             .navigationTitle("The Times")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Picker("Category", selection: $viewModel.selectedCategory) {
-                        ForEach(Category.allCases) { c in
-                            Text(c.label).tag(c)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                }
-            }
         }
     }
 
@@ -69,58 +66,6 @@ struct ContentView: View {
         NavigationView {
             Text("Profile")
                 .navigationTitle("Profile")
-        }
-    }
-
-    private var breakingNewsBanner: some View {
-        HStack {
-            Text("BREAKING")
-                .font(.caption).bold()
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Color.red)
-                .foregroundColor(.white)
-                .cornerRadius(4)
-            Text(viewModel.breakingNews)
-                .font(.caption)
-        }
-        .padding(.vertical, 4)
-    }
-
-    private var featured: some View {
-        VStack(alignment: .leading) {
-            AsyncImage(url: URL(string: viewModel.featuredArticle.imageUrl)) { image in
-                image.resizable().aspectRatio(contentMode: .fill)
-            } placeholder: {
-                Color.gray.opacity(0.3)
-            }
-            .frame(height: 200)
-            .clipped()
-
-            if viewModel.featuredArticle.isLive {
-                Text("LIVE")
-                    .font(.caption).bold()
-                    .padding(6)
-                    .background(Color.red)
-                    .foregroundColor(.white)
-                    .cornerRadius(4)
-                    .offset(x: 16, y: -24)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(viewModel.featuredArticle.title)
-                    .font(.title2).bold()
-                Text(viewModel.featuredArticle.summary)
-                    .font(.body)
-                HStack(spacing: 4) {
-                    Text(viewModel.featuredArticle.source).font(.caption)
-                    Text("•")
-                    Text(viewModel.featuredArticle.publishedDate).font(.caption)
-                }
-                .foregroundColor(.secondary)
-            }
-            .padding(.horizontal)
-            .padding(.bottom)
         }
     }
 }

--- a/SwiftNewsApp/Views/ContentView.swift
+++ b/SwiftNewsApp/Views/ContentView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+enum Screen: Hashable {
+    case home, sections, bookmarks, profile
+}
+
+struct ContentView: View {
+    @State private var selectedTab: Screen = .home
+    @StateObject private var viewModel = NewsViewModel()
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            homeView
+                .tabItem { Label("Home", systemImage: "house") }
+                .tag(Screen.home)
+            sectionsView
+                .tabItem { Label("Sections", systemImage: "square.grid.2x2") }
+                .tag(Screen.sections)
+            bookmarksView
+                .tabItem { Label("Bookmarks", systemImage: "bookmark") }
+                .tag(Screen.bookmarks)
+            profileView
+                .tabItem { Label("Profile", systemImage: "person") }
+                .tag(Screen.profile)
+        }
+    }
+
+    private var homeView: some View {
+        NavigationView {
+            List {
+                breakingNewsBanner
+                if viewModel.selectedCategory == .top {
+                    featured
+                }
+                ForEach(viewModel.articlesByCategory[viewModel.selectedCategory] ?? []) { article in
+                    ArticleRow(article: article)
+                }
+            }
+            .listStyle(.plain)
+            .navigationTitle("The Times")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Picker("Category", selection: $viewModel.selectedCategory) {
+                        ForEach(Category.allCases) { c in
+                            Text(c.label).tag(c)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+            }
+        }
+    }
+
+    private var sectionsView: some View {
+        NavigationView {
+            Text("Sections")
+                .navigationTitle("Sections")
+        }
+    }
+
+    private var bookmarksView: some View {
+        NavigationView {
+            Text("Bookmarks")
+                .navigationTitle("Bookmarks")
+        }
+    }
+
+    private var profileView: some View {
+        NavigationView {
+            Text("Profile")
+                .navigationTitle("Profile")
+        }
+    }
+
+    private var breakingNewsBanner: some View {
+        HStack {
+            Text("BREAKING")
+                .font(.caption).bold()
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.red)
+                .foregroundColor(.white)
+                .cornerRadius(4)
+            Text(viewModel.breakingNews)
+                .font(.caption)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var featured: some View {
+        VStack(alignment: .leading) {
+            AsyncImage(url: URL(string: viewModel.featuredArticle.imageUrl)) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Color.gray.opacity(0.3)
+            }
+            .frame(height: 200)
+            .clipped()
+
+            if viewModel.featuredArticle.isLive {
+                Text("LIVE")
+                    .font(.caption).bold()
+                    .padding(6)
+                    .background(Color.red)
+                    .foregroundColor(.white)
+                    .cornerRadius(4)
+                    .offset(x: 16, y: -24)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(viewModel.featuredArticle.title)
+                    .font(.title2).bold()
+                Text(viewModel.featuredArticle.summary)
+                    .font(.body)
+                HStack(spacing: 4) {
+                    Text(viewModel.featuredArticle.source).font(.caption)
+                    Text("•")
+                    Text(viewModel.featuredArticle.publishedDate).font(.caption)
+                }
+                .foregroundColor(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+    }
+}

--- a/SwiftNewsApp/Views/FeaturedArticleView.swift
+++ b/SwiftNewsApp/Views/FeaturedArticleView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct FeaturedArticleView: View {
+    let article: FeaturedArticle
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            AsyncImage(url: URL(string: article.imageUrl)) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Color.gray.opacity(0.3)
+            }
+            .frame(height: 200)
+            .clipped()
+
+            if article.isLive {
+                Text("LIVE")
+                    .font(.caption).bold()
+                    .padding(6)
+                    .background(Color.red)
+                    .foregroundColor(.white)
+                    .cornerRadius(4)
+                    .offset(x: 16, y: -24)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(article.title)
+                    .font(.title2).bold()
+                Text(article.summary)
+                    .font(.body)
+                HStack(spacing: 4) {
+                    Text(article.source).font(.caption)
+                    Text("•")
+                    Text(article.publishedDate).font(.caption)
+                }
+                .foregroundColor(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.bottom)
+        }
+    }
+}
+
+#Preview {
+    FeaturedArticleView(article: FeaturedArticle(
+        title: "Example", summary: "summary", source: "source", publishedDate: "1h", imageUrl: "", isLive: true))
+}

--- a/SwiftNewsApp/Views/SectionHeaderView.swift
+++ b/SwiftNewsApp/Views/SectionHeaderView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct SectionHeaderView: View {
+    let title: String
+    let subtitle: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.headline)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    SectionHeaderView(title: "Latest News", subtitle: "Stay updated")
+}


### PR DESCRIPTION
## Summary
- refactor `NewsApp` into MVVM structure
- define model structs for `Article`, `FeaturedArticle`, and `Category`
- implement `NewsViewModel` with curated sample data
- split `ContentView` and `ArticleRow` into dedicated view files

## Testing
- `swiftc SwiftNewsApp/Models/*.swift SwiftNewsApp/ViewModels/*.swift SwiftNewsApp/Views/*.swift SwiftNewsApp/NewsApp.swift -o SwiftNewsApp/NewsAppExecutable` *(fails: no such module 'Combine')*


------
https://chatgpt.com/codex/tasks/task_e_685f9ab31dec832ea612cedde411e43e